### PR TITLE
feat: parameter to exclude kms/rds cloudtrail events

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -35,6 +35,7 @@ Metadata:
           - TrailEnableLogFileValidation
           - TrailIncludeGlobalEvents
           - TrailMultiRegion
+          - TrailExcludeManagementEventSources
       - Label:
           default: Retention Options
         Parameters:
@@ -197,6 +198,14 @@ Parameters:
      AllowedValues:
       - true
       - false
+  TrailExcludeManagementEventSources:
+    Type: CommaDelimitedList
+    Default:  "kms.amazonaws.com,rdsdata.amazonaws.com"
+    Description: >-
+      A comma-separated list of Management Event Sources to exclude.
+
+      See the following link for more info:
+      https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html
   SubscriptionEnabled:
     Type: String
     Default: true
@@ -675,6 +684,8 @@ Resources:
         - TrailIsMultiRegion
         - true
         - false
+      EventSelectors:
+        - ExcludeManagementEventSources: !Ref TrailExcludeManagementEventSources
   Snapshot:
     Type: 'Custom::Invoke'
     Condition: InvokeSnapshotOnStart


### PR DESCRIPTION
This is a minimal change for addressing ER-242. As a result of this change, default CloudTrail costs should be lower.