### PR TITLE
make: extra s3 args, add `--acl public-read`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
+S3_CP_ARGS=aws s3 cp --acl public-read
+
 .PHONY: cloudformation
 cloudformation:
-	aws s3 cp templates/collection.yaml s3://observeinc/cloudformation/collection-`semtag final -s minor -o`.yaml
-	aws s3 cp templates/collection.yaml s3://observeinc/cloudformation/collection-latest.yaml
-	aws s3 cp templates/config.yaml s3://observeinc/cloudformation/config-`semtag final -s minor -o`.yaml
-	aws s3 cp templates/config.yaml s3://observeinc/cloudformation/config-latest.yaml
-	aws s3 cp templates/cwmetricsstream.yaml s3://observeinc/cloudformation/cwmetricsstream-`semtag final -s minor -o`.yaml
-	aws s3 cp templates/cwmetricsstream.yaml s3://observeinc/cloudformation/cwmetricsstream-latest.yaml
-	aws s3 cp templates/quicksetup.yaml s3://observeinc/cloudformation/quicksetup-`semtag final -s minor -o`.yaml
-	aws s3 cp templates/quicksetup.yaml s3://observeinc/cloudformation/quicksetup-latest.yaml
-	aws s3 cp templates/vpc.yaml s3://observeinc/cloudformation/vpc-`semtag final -s minor -o`.yaml
-	aws s3 cp templates/vpc.yaml s3://observeinc/cloudformation/vpc-latest.yaml
+	$(S3_CP_ARGS) templates/collection.yaml s3://observeinc/cloudformation/collection-`semtag final -s minor -o`.yaml
+	$(S3_CP_ARGS) templates/collection.yaml s3://observeinc/cloudformation/collection-latest.yaml
+	$(S3_CP_ARGS) templates/config.yaml s3://observeinc/cloudformation/config-`semtag final -s minor -o`.yaml
+	$(S3_CP_ARGS) templates/config.yaml s3://observeinc/cloudformation/config-latest.yaml
+	$(S3_CP_ARGS) templates/cwmetricsstream.yaml s3://observeinc/cloudformation/cwmetricsstream-`semtag final -s minor -o`.yaml
+	$(S3_CP_ARGS) templates/cwmetricsstream.yaml s3://observeinc/cloudformation/cwmetricsstream-latest.yaml
+	$(S3_CP_ARGS) templates/quicksetup.yaml s3://observeinc/cloudformation/quicksetup-`semtag final -s minor -o`.yaml
+	$(S3_CP_ARGS) templates/quicksetup.yaml s3://observeinc/cloudformation/quicksetup-latest.yaml
+	$(S3_CP_ARGS) templates/vpc.yaml s3://observeinc/cloudformation/vpc-`semtag final -s minor -o`.yaml
+	$(S3_CP_ARGS) templates/vpc.yaml s3://observeinc/cloudformation/vpc-latest.yaml
 
 .PHONY: changelog
 changelog:


### PR DESCRIPTION
Makes all uploaded templates public objects. Extracts the AWS CLI args to an argument to ensure that all invocations use the same flags.