### PR TITLE
feat: enable log delivery to S3 via canned ACL

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -301,7 +301,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: Private
+      AccessControl: LogDeliveryWrite
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
Allows S3 bucket access requests to be delivered to this bucket.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#grant-log-delivery-permissions-general

Matches Terraform:

https://github.com/observeinc/terraform-aws-collection/blob/0517ffc4ede1f5e3545672f6543728dc7c02e26a/s3.tf#L31

https://observe.atlassian.net/browse/OB-16832