### PR TITLE
fix: adjust bucket ownership to allow ACLs

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -317,6 +317,9 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -67,12 +67,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: Private
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       LifecycleConfiguration:
         Rules:
         - ExpirationInDays: !If [HasExpirationInDays, !Ref ExpirationInDays, 1]


### PR DESCRIPTION
Recent changes to the default bucket settings flipped ownership to `BucketOwnerEnforced`
(https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-faq.html)

This change incompatible with our existing use of canned ACLs. The result is an error on bucket creation:
```
Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnership; Request ID: 8ACX995SAGE7YF58; S3 Extended Request ID: /9iJTd+6OLVrENDxlKUX3o7bUgepwCY+8cLlq/dFLxbTFzd1uj+MOFbxNDyJEMST2yUrPtA+K9A=; Proxy: null)
```

To work around this error, we can specify `BucketOwnerPreferred` in cases where we use canned ACLs. Since our existing security posture already disallows public access, this is no different from the new and improved defaults.