### PR TITLE
fix(controltower): rename SNS topic to match stack name

### DIFF
--- a/templates/controltower.yaml
+++ b/templates/controltower.yaml
@@ -218,8 +218,8 @@ Resources:
   SNSTopic:
     Type: AWS::SNS::Topic
     Properties:
-      DisplayName: observe-trigger-topic
-      TopicName: observe-trigger-topic
+      DisplayName: !Ref 'AWS::StackName'
+      TopicName: !Ref 'AWS::StackName'
       Subscription:
       - Endpoint: !GetAtt Lambda.Arn
         Protocol: lambda


### PR DESCRIPTION
Resource names must either be random or at least partially derived from the stack name, otherwise it is impossible to install multiple copies of the same stack. Multiple stack copies may be necessary due to forwarding the same data to multiple datastreams, or as a side effect of a botched install or uninstall.