### PR TITLE
feat(controltower): allow configuration of logging verbosity

### DIFF
--- a/templates/controltower.yaml
+++ b/templates/controltower.yaml
@@ -17,6 +17,7 @@ Metadata:
           - LambdaMemorySize
           - LambdaS3CustomRules
           - LambdaS3ReadAny
+          - LambdaVerbosity
 Parameters:
   ObserveCustomer:
     Type: String
@@ -77,6 +78,10 @@ Parameters:
     AllowedValues:
       - 'true'
       - 'false'
+  LambdaVerbosity:
+    Type: Number
+    Default: 3
+    Description: Logging verbosity for Lambda
 Conditions:
   HasLambdaS3CustomRules: !Not
     - !Equals
@@ -137,6 +142,7 @@ Resources:
         Variables:
           OBSERVE_URL: !Sub 'https://${ObserveCustomer}.collect.${ObserveDomain}/v1/http'
           OBSERVE_TOKEN: !Sub '${ObserveToken}'
+          VERBOSITY: !Sub '${LambdaVerbosity}'
           S3_CUSTOM_RULES: !If
             - HasLambdaS3CustomRules
             - !Ref 'LambdaS3CustomRules'


### PR DESCRIPTION
This can be useful when debugging the lambda.