### PR TITLE
feat(controltower): capture config snapshot on subscribe

### DIFF
--- a/templates/controltower.yaml
+++ b/templates/controltower.yaml
@@ -201,7 +201,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'config:DeliverConfigSnapshot'
-            Resource: !Sub 'arn:${AWS::Partition}:s3:::${ManagedResourcePrefix}-BaselineConfigDeliveryChannel'
+            Resource: "*"
       Roles:
         - !Ref LambdaRole
   ping:
@@ -248,6 +248,43 @@ Resources:
                   "aws:SourceAccount": !Ref AWS::AccountId
       Topics:
       - !Ref  SNSTopic
+  EventBridgeTriggerOnSubscribe:
+    Type: 'AWS::Events::Rule'
+    DependsOn:
+      - LambdaDeliverConfigSnapshot
+    Properties:
+      Name: !Sub '${AWS::StackName}SnapshotOnSubscribe'
+      Description: Trigger Config Snapshot on Bucket Notification Subscription
+      EventPattern: !Sub |
+        {
+          "source": ["aws.s3"],
+          "detail": {
+            "eventName": ["PutBucketNotification"],
+            "requestParameters": {
+              "NotificationConfiguration": {
+                "TopicConfiguration": {
+                  "Topic": ["${SNSTopic}"]
+                }
+              }
+            }
+          }
+        }
+      Targets:
+        - Id: ObserveLambda
+          Arn: !GetAtt Lambda.Arn
+          Input: !Sub |
+            {
+              "deliverConfigSnapshot": {
+                "deliveryChannelName": "${ManagedResourcePrefix}-BaselineConfigDeliveryChannel"
+              }
+            }
+  LambdaEventBridgePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref Lambda
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt EventBridgeTriggerOnSubscribe.Arn
 Outputs:
   SNSTopic:
     Description: 'SNS Topic'


### PR DESCRIPTION
Due to Cloudformation limitations, we cannot automatically subscribe S3 buckets to our lambda. This makes it harder to trigger an AWS Config snapshot, since we cannot do so until events are routed appropriately.

This commit works around this problem by installing an EventBridge Rule which triggers on a `PutBucketNotification` event which targets our SNS Topic. On trigger, we notify our lambda that to request an AWS Config snapshot.