### PR TITLE
fix(collection): generate snapshot rule name

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -685,10 +685,8 @@ Resources:
           RoleArn: !GetAtt EventBridgeRole.Arn
   EventBridgePeriodicSnapshot:
     Type: 'AWS::Events::Rule'
-    DependsOn:
-      - LambdaEventBridgePermission
     Properties:
-      Name: !Sub '${AWS::StackName}Snapshot'
+      Description: Trigger API snapshot
       ScheduleExpression: !Ref EventBridgeSnapshotSchedule
       Targets:
         - Id: ObserveLambda
@@ -704,8 +702,7 @@ Resources:
       Action: 'lambda:InvokeFunction'
       FunctionName: !Ref Lambda
       Principal: events.amazonaws.com
-      SourceArn: !Sub >-
-        arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/${AWS::StackName}Snapshot
+      SourceArn: !GetAtt EventBridgePeriodicSnapshot.Arn
   Trail:
     Type: 'AWS::CloudTrail::Trail'
     Condition: TrailIsEnabled


### PR DESCRIPTION
This commit omits providing a name for the eventbridge rule responsible for periodically triggering the API snapshot. In the absence of an explicit name, cloudformation will generate one based on the stack name, the resource name and a random suffix. This is more robust than using the stack name, which can exceed the length constraints of Eventbridge.

As part of this change, we had to modify the dependency chain of affected resources. Previously, we were gating the creation of the rule on the permission to trigger the lambda. This ensures that the first trigger would succeed. By removing the dependency, we risk having the first event trigger prior to being allowed to invoke the lambda. As such, it may fail. This turns out to be acceptable because we always use a custom cloudformation resource to invoke the snapshot directly.