### PR TITLE
feat: set snapshot action timeout parameter

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -25,10 +25,11 @@ Metadata:
           - FirehoseHttpEndpointRetryDuration
           - FirehoseTransformationLambdaArn
       - Label:
-          default: EventBridge Configuration
+          default: API Snapshot Configuration
         Parameters:
           - EventBridgeSnapshotSchedule
           - EventBridgeSnapshotConfig
+          - EventBridgeSnapshotActionTimeout
       - Label:
           default: CloudTrail Configuration
         Parameters:
@@ -130,6 +131,11 @@ Parameters:
     Default: >-
       apigateway:Get*,autoscaling:Describe*,cloudformation:Describe*,cloudformation:List*,cloudfront:List*,dynamodb:Describe*,dynamodb:List*,ec2:Describe*,ecs:Describe*,ecs:List*,eks:Describe*,eks:List*,elasticache:Describe*,elasticbeanstalk:Describe*,elasticfilesystem:Describe*,elasticloadbalancing:Describe*,elasticmapreduce:Describe*,elasticmapreduce:List*,events:List*,firehose:Describe*,firehose:List*,iam:Get*,iam:List*,kinesis:Describe*,kinesis:List*,kms:Describe*,kms:List*,lambda:List*,logs:Describe*,organizations:Describe*,organizations:List*,rds:Describe*,redshift:Describe*,route53:List*,s3:GetBucket*,s3:List*,secretsmanager:List*,sns:Get*,sns:List*,sqs:Get*,sqs:List*,synthetics:Describe*,synthetics:List*
     Description: List of API endpoints which get periodically scraped by Observe Lambda
+
+  EventBridgeSnapshotActionTimeout:
+    Type: Number
+    Default: 90
+    Description: Timeout in seconds for a single API snapshot action. Cap this value below the lambda timeout in order to receive feedback of long running actions.
   LambdaVersion:
     Type: String
     Default: latest
@@ -140,7 +146,7 @@ Parameters:
     Description: The number of simultaneous executions to reserve for the function. Set to -1 to not reserve concurrent executions.
   LambdaTimeout:
     Type: Number
-    Default: 60
+    Default: 120
     Description: >-
       The amount of time that Lambda allows a function to run before stopping
       it. The maximum allowed value is 900 seconds.
@@ -540,6 +546,7 @@ Resources:
         Variables:
           OBSERVE_URL: !Sub 'https://${ObserveCustomer}.collect.${ObserveDomain}/v1/http'
           OBSERVE_TOKEN: !Sub '${ObserveToken}'
+          SNAPSHOT_ACTION_TIMEOUT: !Sub '${EventBridgeSnapshotActionTimeout}s'
           S3_CUSTOM_RULES: !If
             - HasLambdaS3CustomRules
             - !Ref 'LambdaS3CustomRules'


### PR DESCRIPTION
Allow configuration of the `SNAPSHOT_ACTION_TIMEOUT` environment variable in our lambda.

Since our cloudformation stack already takes a `LambdaTimeout` parameter in seconds, I decided to stick to type `Number` for consistency. We pass in the value to the lambda by appending `s`.