### PR TITLE
fix(lambda): bump timeout and memory size based on failure data

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -139,13 +139,13 @@ Parameters:
     Description: The number of simultaneous executions to reserve for the function. Set to -1 to not reserve concurrent executions.
   LambdaTimeout:
     Type: Number
-    Default: 60
+    Default: 120
     Description: >-
       The amount of time that Lambda allows a function to run before stopping
       it. The maximum allowed value is 900 seconds.
   LambdaMemorySize:
     Type: Number
-    Default: 128
+    Default: 256
     MinValue: 128
     MaxValue: 10240
     Description: >-


### PR DESCRIPTION
We have been seeing a number of lambda snapshot failures in prod. These failures were tracked down to larger snapshots taking longer than 60 seconds. We are bumping the timeout to 120 for slower failures but more reliable first runs