### PR TITLE
fix: remove duplicate log subscription

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -512,16 +512,6 @@ Resources:
               - 'firehose:PutRecord'
               - 'firehose:PutRecordBatch'
             Resource: !GetAtt DeliveryStream.Arn
-  DeliveryStreamLogsSubscriptionFilter:
-    Type: 'AWS::Logs::SubscriptionFilter'
-    Condition: SubscriptionIsEnabled
-    DependsOn:
-      - DeliveryStreamPolicy
-    Properties:
-      DestinationArn: !GetAtt 'DeliveryStream.Arn'
-      FilterPattern: ''
-      LogGroupName: !Ref 'LambdaLogGroup'
-      RoleArn: !GetAtt 'CloudWatchLogsRole.Arn'
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:


### PR DESCRIPTION
Removes a duplicate CloudWatch Logs subscription filter. The resource name suggests it should be attached to the delivery stream group. Instead, it's a duplicate of `LambdaLogsSubscriptionFilter`, where both contain `LogGroupName: !Ref 'LambdaLogGroup'`.  This means that Lambda's logs are delivered to the Kinesis delivery stream (and in turn Observe) twice. 

It's unclear whether AWS would allow a circular relationship, where the subscription points to the same delivery stream that uses the log group as an output for its logs. AWS rejects a similar circular setup with Lambda.

For now, since the behavior of this resource has never matched the description, I've removed it.