### PR TITLE
chore: run `cfn-lint` on templates

### DIFF
--- a/.github/workflows/cloudformation.yml
+++ b/.github/workflows/cloudformation.yml
@@ -1,0 +1,15 @@
+name: CloudFormation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scottbrenner/cfn-lint-action@v2
+      - run: cfn-lint -t templates/*

--- a/templates/controltower.yaml
+++ b/templates/controltower.yaml
@@ -69,7 +69,7 @@ Parameters:
       submitted to Observe.
   LambdaS3ReadAny:
     Type: String
-    Default: false
+    Default: 'false'
     Description: >-
       Grant the lambda S3 read only access to all buckets. This simplifies the
       process of subscribing new buckets to the lambda. The lambda function


### PR DESCRIPTION
Currently, we have no formal testing in this repository to verify that templates will work.  Typos or invalid YAML could be released, resulting in breakage. 

This PR adds [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) to check the structure of the templates and identify any issues that can be detected through static analysis. This includes both syntax (e.g., function calls) and configuration like resources and their parameters. 

This at least ensures that CloudFormation should accept the template. Further validation would require deploying into a real AWS account and having CloudFormation create actual resources.

The action, in addition to installing `cfn-lint`, provides a [problem matcher](https://github.com/ScottBrenner/cfn-lint-action/blob/main/.github/cfn-lint.json) for its output. This enables actions to render these lint issues in the UI:


![](https://raw.githubusercontent.com/ScottBrenner/cfn-lint-action/main/.github/cfn-lint-pull-request.png)
