### PR TITLE
fix: make sure lambda log group is successfully deleted on rollback

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -519,15 +519,26 @@ Resources:
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:
-      LogGroupName: !Sub '/aws/lambda/${Lambda}'
+      LogGroupName: !Sub
+        - '/aws/lambda/${LambdaName}'
+        - LambdaName: !If
+            - LambdaSetToStackNameIsEnabled
+            - !Ref 'AWS::StackName'
+            - !Join
+                - ''
+                - - !Select [ 0, !Split [ 'LambdaRole', !Sub '${LambdaRole}' ] ]
+                  - 'Lambda'
+                  - !Select [ 1, !Split [ 'LambdaRole', !Sub '${LambdaRole}' ] ]
       RetentionInDays: !Ref LogGroupExpirationInDays
   Lambda:
     Type: 'AWS::Lambda::Function'
+    DependsOn:
+        - LambdaLogGroup
     Properties:
       FunctionName: !If
         - LambdaSetToStackNameIsEnabled
         - !Ref 'AWS::StackName'
-        - !Ref 'AWS::NoValue'
+        - !Select [ 3, !Split ['/', !Sub '${LambdaLogGroup}'] ]
       Handler: main
       Role: !GetAtt LambdaRole.Arn
       Environment:

--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -538,7 +538,7 @@ Resources:
       FunctionName: !If
         - LambdaSetToStackNameIsEnabled
         - !Ref 'AWS::StackName'
-        - !Select [ 3, !Split ['/', !Sub '${LambdaLogGroup}'] ]
+        - !Select [ 3, !Split [ '/', !Sub '${LambdaLogGroup}' ] ]
       Handler: main
       Role: !GetAtt LambdaRole.Arn
       Environment:


### PR DESCRIPTION
#21 inadvertently introduced a race during stack deletion or rollback. Previously, Lambda explicitly depended on LambdaLogGroup. Allowing the option to auto-generate the lambda name in #21 and then using that to set the name of LambdaLogGroup swapped the polarity of the dependency. If the log group is deleted while the lambda is still up (which this guarantees), there is a window in which the lambda could still be triggered and recreate its log group outside of the control of the CF stack. Future attempts to install the collection stack with the same name will then fail, because the log group already exists