### PR TITLE
fix: deprecate go1.x for provided.al2

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -540,7 +540,7 @@ Resources:
         - LambdaSetToStackNameIsEnabled
         - !Ref 'AWS::StackName'
         - !Select [ 3, !Split [ '/', !Sub '${LambdaLogGroup}' ] ]
-      Handler: main
+      Handler: bootstrap
       Role: !GetAtt LambdaRole.Arn
       Environment:
         Variables:
@@ -556,14 +556,16 @@ Resources:
           - RegionMap
           - !Ref 'AWS::Region'
           - BucketName
-        S3Key: !Sub 'lambda/observer/${LambdaVersion}.zip'
-      Runtime: go1.x
+        S3Key: !Sub 'lambda/observer/arm64/${LambdaVersion}.zip'
+      Runtime: provided.al2
       MemorySize: !Ref LambdaMemorySize
       Timeout: !Ref LambdaTimeout
       ReservedConcurrentExecutions: !If
        - HasReservedConcurrency
        - !Ref LambdaReservedConcurrentExecutions
        - !Ref 'AWS::NoValue'
+      Architectures: 
+        - arm64
   LambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/templates/controltower.yaml
+++ b/templates/controltower.yaml
@@ -160,7 +160,7 @@ Resources:
       - LambdaLogGroup
     Properties:
       FunctionName: !Ref 'AWS::StackName'
-      Handler: main
+      Handler: bootstrap
       Role: !GetAtt LambdaRole.Arn
       Environment:
         Variables:
@@ -176,14 +176,16 @@ Resources:
           - RegionMap
           - !Ref 'AWS::Region'
           - BucketName
-        S3Key: !Sub 'lambda/observer/${LambdaVersion}.zip'
-      Runtime: go1.x
+        S3Key: !Sub 'lambda/observer/arm64/${LambdaVersion}.zip'
+      Runtime: provided.al2
       MemorySize: !Ref LambdaMemorySize
       Timeout: !Ref LambdaTimeout
       ReservedConcurrentExecutions: !If
        - HasReservedConcurrency
        - !Ref LambdaReservedConcurrentExecutions
        - !Ref 'AWS::NoValue'
+      Architectures: 
+        - arm64
   LambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/templates/cwmetricspull.yaml
+++ b/templates/cwmetricspull.yaml
@@ -118,7 +118,7 @@ Resources:
       - LambdaLogGroup
     Properties:
       FunctionName: !Ref 'AWS::StackName'
-      Handler: main
+      Handler: bootstrap
       Role: !GetAtt LambdaRole.Arn
       Environment:
         Variables:
@@ -129,14 +129,16 @@ Resources:
           - RegionMap
           - !Ref 'AWS::Region'
           - BucketName
-        S3Key: !Sub 'lambda/observer/${LambdaVersion}.zip'
-      Runtime: go1.x
+        S3Key: !Sub 'lambda/observer/arm64/${LambdaVersion}.zip'
+      Runtime: provided.al2
       MemorySize: !Ref LambdaMemorySize
       Timeout: !Ref LambdaTimeout
       ReservedConcurrentExecutions: !If
        - HasReservedConcurrency
        - !Ref LambdaReservedConcurrentExecutions
        - !Ref 'AWS::NoValue'
+      Architectures: 
+        - arm64
   LambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/templates/quicksetup.yaml
+++ b/templates/quicksetup.yaml
@@ -82,7 +82,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Ref 'AWS::StackName'
-      Handler: main
+      Handler: bootstrap
       Role: !GetAtt 'role.Arn'
       Environment:
         Variables:
@@ -94,11 +94,13 @@ Resources:
             - !Ref 'AWS::NoValue'
       Code:
         S3Bucket: !FindInMap [RegionMap, !Ref 'AWS::Region', BucketName]
-        S3Key: !Sub 'lambda/observer/${Version}.zip'
-      Runtime: go1.x
+        S3Key: !Sub 'lambda/observer/arm64/${Version}.zip'
+      Runtime: provided.al2
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
       ReservedConcurrentExecutions: !Ref ReservedConcurrentExecutions
+      Architectures: 
+        - arm64
   role:
     Type: AWS::IAM::Role
     Properties:

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -112,7 +112,7 @@ Resources:
       - lambdaLogGroup
     Properties:
       FunctionName: !Ref 'AWS::StackName'
-      Handler: main
+      Handler: bootstrap
       Role: !GetAtt 'role.Arn'
       Environment:
         Variables:
@@ -124,14 +124,16 @@ Resources:
             - !Ref 'AWS::NoValue'
       Code:
         S3Bucket: !FindInMap [RegionMap, !Ref 'AWS::Region', BucketName]
-        S3Key: !Sub 'lambda/observer/${Version}.zip'
+        S3Key: !Sub 'lambda/observer/arm64/${Version}.zip'
       VpcConfig:
         SecurityGroupIds: !Ref SecurityGroupIds
         SubnetIds: !Ref SubnetIds
-      Runtime: go1.x
+      Runtime: provided.al2
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
       ReservedConcurrentExecutions: !Ref ReservedConcurrentExecutions
+      Architectures: 
+        - arm64
   role:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
AWS is deprecating the lambda go 1.x runtime.

Migrate our runtime to arm64 architecture / provided.al2 runtime