### PR TITLE
fix: resolve the cfn-lint error

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -339,7 +339,6 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
@@ -393,6 +392,11 @@ Resources:
               Service: cloudtrail.amazonaws.com
             Action: 's3:PutObject'
             Resource: !Sub 'arn:${AWS::Partition}:s3:::${Bucket}/AWSLogs/${AWS::AccountId}/*'
+          - Effect: Allow
+            Principal:
+              Service: 'logging.s3.amazonaws.com'
+            Action: 's3:PutObject'
+            Resource: !Sub 'arn:${AWS::Partition}:s3:::${Bucket}/*'
   DeliveryStreamLogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:


### PR DESCRIPTION
AWS wants folks to migrate away from this property ( [1](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-bucket.html#cfn-s3-bucket-accesscontrol), [2](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html) )

I verified that installing the collection cloudformation data does get collected -- it's unclear to me if this is a sufficient test

![image](https://github.com/observeinc/cloudformation-aws-collection/assets/131207535/f399350d-0c03-4615-ab51-4db10ec79c73)

![image](https://github.com/observeinc/cloudformation-aws-collection/assets/131207535/918b7a3a-7d3e-45cf-b25f-0251e9efde2c)
