### PR TITLE
fix: CS-522 update default memory for lambda

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -147,7 +147,7 @@ Parameters:
       it. The maximum allowed value is 900 seconds.
   LambdaMemorySize:
     Type: Number
-    Default: 256
+    Default: 2048
     MinValue: 128
     MaxValue: 10240
     Description: >-


### PR DESCRIPTION
update default memory for Lambda to 2048 to avoid issues with pocs