### PR TITLE
chore: Update Lambda Runtime to provided.al2023

### DIFF
--- a/templates/collection.yaml
+++ b/templates/collection.yaml
@@ -617,7 +617,7 @@ Resources:
           - !Ref 'AWS::Region'
           - BucketName
         S3Key: !Sub 'lambda/observer/arm64/${LambdaVersion}.zip'
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !Ref LambdaMemorySize
       Timeout: !Ref LambdaTimeout
       ReservedConcurrentExecutions: !If

--- a/templates/controltower.yaml
+++ b/templates/controltower.yaml
@@ -209,7 +209,7 @@ Resources:
           - !Ref 'AWS::Region'
           - BucketName
         S3Key: !Sub 'lambda/observer/arm64/${LambdaVersion}.zip'
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !Ref LambdaMemorySize
       Timeout: !Ref LambdaTimeout
       ReservedConcurrentExecutions: !If

--- a/templates/cwmetricspull.yaml
+++ b/templates/cwmetricspull.yaml
@@ -130,7 +130,7 @@ Resources:
           - !Ref 'AWS::Region'
           - BucketName
         S3Key: !Sub 'lambda/observer/arm64/${LambdaVersion}.zip'
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !Ref LambdaMemorySize
       Timeout: !Ref LambdaTimeout
       ReservedConcurrentExecutions: !If

--- a/templates/quicksetup.yaml
+++ b/templates/quicksetup.yaml
@@ -95,7 +95,7 @@ Resources:
       Code:
         S3Bucket: !FindInMap [RegionMap, !Ref 'AWS::Region', BucketName]
         S3Key: !Sub 'lambda/observer/arm64/${Version}.zip'
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
       ReservedConcurrentExecutions: !Ref ReservedConcurrentExecutions

--- a/templates/vpc.yaml
+++ b/templates/vpc.yaml
@@ -128,7 +128,7 @@ Resources:
       VpcConfig:
         SecurityGroupIds: !Ref SecurityGroupIds
         SubnetIds: !Ref SubnetIds
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
       ReservedConcurrentExecutions: !Ref ReservedConcurrentExecutions


### PR DESCRIPTION
Upgrade Lambda functions in the CloudFormation templates from the deprecated `provided.al2` runtime to the recommended `provided.al2023` runtime, ensuring continued support and security updates beyond the July 2026 deprecation date.

Deployed new stack using updated runtime and validated events were received.
```
aws lambda get-function-configuration \
  --function-name jdd-observe-runtime-test \
  --query '[Runtime,Architectures[0]]' \
  --output table
--------------------------
|GetFunctionConfiguration|
+------------------------+
|  provided.al2023       |
|  arm64                 |
+------------------------+
